### PR TITLE
Correct link to Pong

### DIFF
--- a/resources/blog/games-in-elm/part-0/Making-Pong.html
+++ b/resources/blog/games-in-elm/part-0/Making-Pong.html
@@ -182,7 +182,7 @@ within epsilon n x <span class="fu">=</span> x <span class="fu">&gt;</span> n <s
 <p>We can now define a view of the game (a signal of Elements) that changes as the GameState changes. This is what the users will see.</p>
 <p>And finally, we display the view of the game to the user!</p>
 <pre class="sourceCode literate haskell"><code class="sourceCode haskell">main <span class="fu">=</span> lift2 display Window.dimensions gameState</code></pre>
-<p>And that is it! <a href="http://elm-lang.org/misc/Pong.html">Pong in Elm</a>!</p>
+<p>And that is it! <a href="http://elm-lang.org/blog/games-in-elm/part-0/Pong.html">Pong in Elm</a>!</p>
 <h1 id="post-script">Post Script</h1>
 <h2 id="learn-by-doing-programming-challenges">Learn by Doing: Programming Challenges</h2>
 <p>If you want to learn more about making games in Elm, try tackling some of these challenges:</p>


### PR DESCRIPTION
The [current link](http://elm-lang.org/misc/Pong.html) to Pong at the end of the blog post just returns this error:

> Parse error at (line 1, column 1):
> unexpected end of input
> expecting reserved word 'module', reserved word 'import' or at least one datatype or variable definition

This commit changes the link target to [this page](http://elm-lang.org/blog/games-in-elm/part-0/Pong.html).
