### PR TITLE
Fixed compile.bat mv command

### DIFF
--- a/compile.bat
+++ b/compile.bat
@@ -1,7 +1,6 @@
-
 taskkill /F /IM ElmServer.exe
 cd server
 ghc --make -O2 -threaded -hidir ghc_output -odir ghc_output Server.hs -o ElmServer
-mv ElmServer.exe ..
+move ElmServer.exe ..
 cd ..
 start "Elm Server" ElmServer.exe


### PR DESCRIPTION
mv hasn't existed since at least Windows XP, but the move command works in this case

I have tested this on Windows 7 and it works perfectly. It should also work on Windows XP, Vista, and 8.
