### PR TITLE
Fix the link to the examples in Graphics.Inputs doc page.

### DIFF
--- a/elm-docs/structure.json
+++ b/elm-docs/structure.json
@@ -225,7 +225,7 @@
      ]
   }
 , { "module" : "Graphics.Input"
-  , "description" : "See [the walkthrough on `Graphics.Input`](/) to get a better understanding of how this library works and why it is designed this way."
+  , "description" : "See [the Input examples](/examples/Basic.elm) to get a better understanding of how this library works and why it is designed this way."
   , "sections" :
     [{"name":"One-way Inputs",
       "values":["button","customButton","field","email","password",


### PR DESCRIPTION
The previous link was to the home page and the use of the word "walkthrough" was confusing.
