### PR TITLE
Use Cabal as the build system instead of bash scripts

### DIFF
--- a/ElmLang.cabal
+++ b/ElmLang.cabal
@@ -1,0 +1,39 @@
+name:                ElmLang
+version:             0.1.0.0
+synopsis:            elm-lang.org web site
+description:         Server and content for the Elm Language web site.
+homepage:            http://elm-lang.org/
+license:             BSD3
+license-file:        LICENSE
+author:              Evan Czaplicki
+maintainer:          info@elm-lang.org
+copyright:           (c) 2012-2013 Evan Czaplicki
+
+build-type:          Simple
+extra-source-files:  README.md
+cabal-version:       >=1.10
+
+extra-tmp-files:       public/build
+                     , public/cache
+
+executable ElmServer
+  main-is:             Server.hs
+  other-extensions:    OverloadedStrings
+  ghc-options:         -threaded -O2
+  build-depends:       base >=4.6 && <4.7
+                     , containers >=0.5 && <0.6
+                     , bytestring >=0.10 && <0.11
+                     , aeson >=0.6 && <0.7
+                     , filepath >=1.3 && <1.4
+                     , directory >=1.2 && <1.3
+                     , parsec >=3.1 && <3.2
+                     , blaze-html >=0.6 && <0.7
+                     , HTTP >=4000.2 && <4000.3
+                     , blaze-markup >=0.5 && <0.6
+                     , Elm >=0.9 && <0.10
+                     , happstack-server >=7.3 && <7.4
+                     , mtl >=2.1 && <2.2
+                     , process >=1.1 && <1.2
+
+  hs-source-dirs:      server
+  default-language:    Haskell2010

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c)2012, Evan Czaplicki
+Copyright (c) 2012-2013 Evan Czaplicki
 
 All rights reserved.
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # elm-lang.org: a template for creating websites in Elm
 
-This project contains all of the source files used to create [elm-lang.org](http://elm-lang.org/),
-the home-page of the Elm programming language.
+This project contains all of the source files used to create
+[elm-lang.org](http://elm-lang.org/), the home-page of the Elm programming
+language.
 
-The project provides a general structure for creating your own Elm website, mixing Elm, images,
-videos, HTML/CSS/JS, and whatever else you need.
+The project provides a general structure for creating your own Elm website,
+mixing Elm, images, videos, HTML/CSS/JS, and whatever else you need.
 
-This project includes a Haskell server that determines how to serve each kind of file, so you
-only need to think about the content.
+This project includes a Haskell server that determines how to serve each kind of
+file, so you only need to think about the content.
 
 ### Set up
 
@@ -16,27 +17,26 @@ First make sure that you have the Elm compiler installed
 
 Then follow these steps to get this all running on your local machine:
 
-###### Unix / Mac
-
-- Fork this project.
-- Run `bash compile.sh`. This will compile the server.
+- Clone this project.
+- Run `cabal clean && cabal build && cabal install`. Note the `clean` step is
+  often necessary if you previously compiled with a different version of the
+  server due to stale compiled Elm files.
 - Run `./ElmServer` to start the server.
 
-###### Windows
-
-- Fork this project.
-- Run `compile.bat`. This will compile the server and start it on your machine.
-
-Great! You should be set up with [elm-lang.org](http://elm-lang.org/) running at [localhost:8000/](http://localhost:8000/).
+Great! You should be set up with [elm-lang.org](http://elm-lang.org/) running at
+[localhost:8000/](http://localhost:8000/).
 
 ### Project Structure
 
-- `public/` &mdash; all of the .elm files used for the site. This makes up the majority of client-side code.
-  You can change/delete the existing files and add entirely new files. The changes, deletions, and additions will
-  be served automatically.
-- `resources/` &mdash; the various resources needed for Elm. This is where you put all of your non-Elm content,
-  like images, videos, JavaScript code, etc.
-- `server/` &mdash; the Haskell files responsible for serving everything from .elm files to images. Look here
-  if you need to change how a particular resource is served or if you want to disable some of the sites
-  features (such as the online editor).
+- `public/` &mdash; all of the .elm files used for the site. This makes up the
+  majority of client-side code.  You can change/delete the existing files and
+  add entirely new files. The changes, deletions, and additions will be served
+  automatically.
 
+- `resources/` &mdash; the various resources needed for Elm. This is where you
+  put all of your non-Elm content, like images, videos, JavaScript code, etc.
+
+- `server/` &mdash; the Haskell files responsible for serving everything from
+  .elm files to images. Look here if you need to change how a particular
+  resource is served or if you want to disable some of the sites features (such
+  as the online editor).

--- a/Setup.hs
+++ b/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/compile.bat
+++ b/compile.bat
@@ -1,6 +1,0 @@
-taskkill /F /IM ElmServer.exe
-cd server
-ghc --make -O2 -threaded -hidir ghc_output -odir ghc_output Server.hs -o ElmServer
-move ElmServer.exe ..
-cd ..
-start "Elm Server" ElmServer.exe

--- a/compile.sh
+++ b/compile.sh
@@ -1,4 +1,0 @@
-cd server
-ghc --make -O2 -threaded -hidir ghc_output -odir ghc_output Server.hs -o ElmServer
-mv ElmServer ..
-cd ..


### PR DESCRIPTION
This is just a suggestion here so feel free to close if you don't want to go this route.

I made this PR because when I used the `compile.sh` script the server didn't work for me. This turned out to be because the `public/build` and `public/cache` directories existed and I needed to delete them manually. Rather than fixing the custom build scripts for *nix and Windows to be idempotent I thought it would be preferable to leverage a 'normal' Haskell build pipeline that would work consistently across platforms.
