### PR TITLE
Add embedded LaTeX math example

### DIFF
--- a/public/examples/Elements/Markdown.elm
+++ b/public/examples/Elements/Markdown.elm
@@ -11,6 +11,7 @@ text elements. You can easily make:
   - Images
   - **Bold**, *italic*, and `monospaced` text
   - Lists (numbered, nested, multi-paragraph bullets)
+  - Embedded LaTeX math: $e^{i\pi} = -1$
 
 It all feels quite natural to type. For more information on Markdown,
 see [this site](http://daringfireball.net/projects/markdown/).


### PR DESCRIPTION
The markdown syntax is missing from this page as well: http://elm-lang.org/learn/Syntax.elm.

I can see why though, since I couldn't find a way to escape the sequence of characters needed. Can someone think of a good workaround?
