### PR TITLE
Add alert if you leave the editor page.

### DIFF
--- a/resources/misc/editor.js
+++ b/resources/misc/editor.js
@@ -1,6 +1,10 @@
 var editor = null;
 var elmDocs = null;
 
+window.onbeforeunload = function(e) {
+    return 'You will lose any changes you have made to your Elm program if you leave this page.';
+};
+
 function compile() {
     var form = document.getElementById('inputForm');
     form.submit();


### PR DESCRIPTION
I added this before I did live coding in a presentation since I was terrified of losing my changes if I accidentally reloaded the editor page.

This change just makes an alert pop up with the `beforeunload` event in the browser. It does _not_ do any detection of whether or not the program has changed. Please let me know if you really think this alert should only pop up when the code has changed and I can take a look at making that happen. Any pointers would be appreciated to implement that change. Otherwise perhaps that could be an additional feature added in a separate PR?

Thanks for the review!
