### PR TITLE
Specify compatible version of text with snap-server

### DIFF
--- a/elm-website.cabal
+++ b/elm-website.cabal
@@ -28,7 +28,7 @@ executable run-elm-website
                      , containers
                      , cmdargs
                      , directory
-                     , Elm >= 0.10.0.2
+                     , Elm >= 0.10.1
                      , filepath
                      , snap-core
                      , snap-server


### PR DESCRIPTION
There was a release recently of text and snap-server hasn't updated to
allow the 1.0 release. Doesn't build on my machine without this.
