### PR TITLE
Use fromPolar in clock example

### DIFF
--- a/public/examples/Intermediate/Clock.elm
+++ b/public/examples/Intermediate/Clock.elm
@@ -9,4 +9,4 @@ clock t = collage 400 400 [ filled    lightGrey   (ngon 12 110)
 
 hand clr len time =
   let angle = degrees (90 - 6 * inSeconds time)
-  in  traced (solid clr) <| segment (0,0) (len * cos angle, len * sin angle)
+  in  segment (0,0) (fromPolar (len,angle)) |> traced (solid clr)


### PR DESCRIPTION
This has been driving me nuts forever, especially since I like to show this example to other people. We have `fromPolar` in Basics so me might as well use it.

Arguably we should add type annotations while we're at it, but this is simple.
