### PR TITLE
Fix broken link to records paper in learn/Records.elm

### DIFF
--- a/public/learn/Records.elm
+++ b/public/learn/Records.elm
@@ -236,6 +236,7 @@ the latest field taking precedence over the earlier ones. Check out
 [this paper][records] for more information on this.
 
  [records]: http://research.microsoft.com/pubs/65409/scopedlabels.pdf "Extensible Records"
+
 We can combine the add and delete operations to rename fields.
 
     renameName person = { person - name | surname = person.name }


### PR DESCRIPTION
[This section](http://elm-lang.org/learn/Records.elm#adding-deleting-and-renaming-fields) of the documentation on records has a broken link which also removes the paragraph following it from the output.
