### PR TITLE
Update elm-reactor version in installation documentation

### DIFF
--- a/frontend/public/Install.elm
+++ b/frontend/public/Install.elm
@@ -80,7 +80,7 @@ Then run the following commands:
 cabal update
 cabal install cabal-install
 cabal install -j elm-compiler-0.14 elm-package-0.2 elm-make-0.1
-cabal install -j elm-repl-0.4 elm-reactor-0.2
+cabal install -j elm-repl-0.4 elm-reactor-0.2.0.1
 ```
 
 This will take some time, but when it is done, all of these executables should


### PR DESCRIPTION
Ran into an installation issue that's described here: https://groups.google.com/forum/?fromgroups#!topic/elm-discuss/fsiDKEVSJXY The solution is to use elm-reactor-0.2.0.1 instead of 0.2.
