### PR TITLE
Escape backslash in example code

### DIFF
--- a/frontend/public/learn/Architecture.elm
+++ b/frontend/public/learn/Architecture.elm
@@ -155,7 +155,7 @@ type Action = State -> State
 removeTask : Int -> Action
 removeTask id state =
     { state |
-        tasks <- filter (\task -> task.id /= id) state.tasks
+        tasks <- filter (\\task -> task.id /= id) state.tasks
     }
 ```
 


### PR DESCRIPTION
This is handled in Syntax.elm with escaping as well. A raw string literal syntax could be nicer, but that's obviously a separate issue!
