### PR TITLE
Fix temporary js file deletion issue on windows

### DIFF
--- a/backend/Compile.hs
+++ b/backend/Compile.hs
@@ -31,7 +31,7 @@ compileSource source =
         Right _ ->
           do  jsSource <- readFile jsFilePath
               removeFile elmFilePath
-              removeFile jsFilePath
+              length jsSource `seq` removeFile jsFilePath
               removeArtifacts moduleName
               return (Right (moduleName, jsSource))
 


### PR DESCRIPTION
Fix the following error:
DeleteFile ".\Temp9125.js": permission denied (The process cannot access the file because it is being used by another process.)

When running the site locally on windows and hitting "compile" button.

The fix force the evaluation like it's done in the stable branch
