### PR TITLE
add note to original virtual dom post about new post

### DIFF
--- a/src/pages/blog/blazing-fast-html.elm
+++ b/src/pages/blog/blazing-fast-html.elm
@@ -21,6 +21,8 @@ main =
 
 content = """
 
+> **Note:** The ideas discussed in this post are still relevant but some of the specifics are now outdated. You can read an updated version of this post [here][round-2-post].
+
 The new [elm-html][] library lets you use
 HTML and CSS directly in Elm. Want to use flexbox? Want to keep using existing
 style sheets? Elm now makes all of this pleasant and *fast*. For example, when
@@ -32,6 +34,7 @@ popular entries:
 [todo]: http://evancz.github.io/elm-todomvc/
 [code]: https://github.com/evancz/elm-todomvc/blob/master/Todo.elm
 [bench]: https://evancz.github.io/todomvc-perf-comparison
+[round-2-post]: http://elm-lang.org/blog/blazing-fast-html-round-two
 
 <a href="https://evancz.github.io/todomvc-perf-comparison">
 <img src="/assets/blog/virtual-dom-charts-old/sampleResults.png"


### PR DESCRIPTION
Some of the information in the first virual dom post is no longer up to date (nor are the benchmarks).  The first post still shows up first on google as well.  I think a note at the top will help newcomers find the updated post more quickly.

![elm virtual dom - google search 2017-01-07 14-05-14](https://cloud.githubusercontent.com/assets/1872899/21744586/bb7f0b0c-d4e6-11e6-9f9f-852a97ef6d56.png)
