### PR TITLE
read checkbox state from model in view of checkbox example

### DIFF
--- a/src/examples/checkboxes.elm
+++ b/src/examples/checkboxes.elm
@@ -1,11 +1,12 @@
+module Main exposing (..)
+
 import Html exposing (Html, beginnerProgram, fieldset, input, label, text)
-import Html.Attributes exposing (style, type_)
+import Html.Attributes exposing (style, type_, checked)
 import Html.Events exposing (onClick)
 
 
-
 main =
-  beginnerProgram { model = optOut, update = update, view = view }
+    beginnerProgram { model = optOut, update = update, view = view }
 
 
 
@@ -13,15 +14,15 @@ main =
 
 
 type alias Model =
-  { notifications : Bool
-  , autoplay : Bool
-  , location : Bool
-  }
+    { notifications : Bool
+    , autoplay : Bool
+    , location : Bool
+    }
 
 
 optOut : Model
 optOut =
-  Model True True True
+    Model False False False
 
 
 
@@ -29,22 +30,22 @@ optOut =
 
 
 type Msg
-  = ToggleNotifications
-  | ToggleAutoplay
-  | ToggleLocation
+    = ToggleNotifications
+    | ToggleAutoplay
+    | ToggleLocation
 
 
 update : Msg -> Model -> Model
 update msg model =
-  case msg of
-    ToggleNotifications ->
-      { model | notifications = not model.notifications }
+    case msg of
+        ToggleNotifications ->
+            { model | notifications = not model.notifications }
 
-    ToggleAutoplay ->
-      { model | autoplay = not model.autoplay }
+        ToggleAutoplay ->
+            { model | autoplay = not model.autoplay }
 
-    ToggleLocation ->
-      { model | location = not model.location }
+        ToggleLocation ->
+            { model | location = not model.location }
 
 
 
@@ -53,18 +54,23 @@ update msg model =
 
 view : Model -> Html Msg
 view model =
-  fieldset []
-    [ checkbox ToggleNotifications "Email Notifications"
-    , checkbox ToggleAutoplay "Video Autoplay"
-    , checkbox ToggleLocation "Use Location"
-    ]
+    fieldset []
+        [ checkbox ToggleNotifications "Email Notifications" model.notifications
+        , checkbox ToggleAutoplay "Video Autoplay" model.autoplay
+        , checkbox ToggleLocation "Use Location" model.location
+        ]
 
 
-checkbox : msg -> String -> Html msg
-checkbox msg name =
-  label
-    [ style [("padding", "20px")]
-    ]
-    [ input [ type_ "checkbox", onClick msg ] []
-    , text name
-    ]
+checkbox : msg -> String -> Bool -> Html msg
+checkbox msg name isChecked =
+    label
+        [ style [ ( "padding", "20px" ) ]
+        ]
+        [ input
+            [ type_ "checkbox"
+            , checked isChecked
+            , onClick msg
+            ]
+            []
+        , text name
+        ]


### PR DESCRIPTION
The [current example for using checkboxes](http://elm-lang.org/examples/checkboxes) does track the checkboxes' states within the model. However, the view does not actually read checkboxes' states from the model. It relies on HTML keeping track of the checkbox state.

"Why the model then?", one might ask.

This PR changes the example so that the view reads checkbox states from the model. The intention is to make the example more compelling and explanatory.

(elm-format changed indentation to four spaces. let me know if I should revert to two spaces instead.)