### PR TITLE
Make time example a bit more intuitive.

### DIFF
--- a/src/examples/time.elm
+++ b/src/examples/time.elm
@@ -61,7 +61,7 @@ view : Model -> Html Msg
 view model =
   let
     angle =
-      turns (Time.inMinutes model)
+      (Time.inSeconds model) / (2 * pi)
 
     handX =
       toString (50 + 40 * cos angle)

--- a/src/examples/time.elm
+++ b/src/examples/time.elm
@@ -61,7 +61,7 @@ view : Model -> Html Msg
 view model =
   let
     angle =
-      (Time.inSeconds model) / (2 * pi)
+      Time.inSeconds model * 2 * pi / 60
 
     handX =
       toString (50 + 40 * cos angle)


### PR DESCRIPTION
I think this approach might be better. It assumes some familiarity with trigonometry but so does using `sin` and `cos` further down. It also avoids the use of `turns` which was not introduced and it does not call `inMinutes`. The SVG shows the seconds hand so it is a bit confusing to call `inMinutes` in the source code.