### PR TITLE
Add DEV Community to community page

### DIFF
--- a/src/pages/community.elm
+++ b/src/pages/community.elm
@@ -19,6 +19,7 @@ community = """
   * [Reddit][reddit]
   * [Slack][slack]
   * [Twitter][twitter]
+  * [DEV Community][dev-community]
   * [Real Life][real-life]
   * [Contributing](#contribute)
 
@@ -74,6 +75,15 @@ respectful to everyone.
 Both [@elmlang][twitter] and [@czaplic](https://twitter.com/czaplic) tweet about
 Elm a lot. The #elmlang hashtag is commonly used. Using #elm is okay, but people
 tweet about weird stuff with that one sometimes.
+
+
+## DEV Community
+
+[dev-community]:https://dev.to/t/elm
+
+[DEV Elm tag][dev-community] is a place to share Elm projects, articles and tutorials
+as well as start discussions and ask for feedback on Elm-related topics. 
+Developers of all skill-levels are welcome to take part.
 
 
 ## Real Life


### PR DESCRIPTION
[DEV Community](https://dev.to) is a burgeoning source of guidance and discussion on software topics, especially web dev. This will be a useful link to point to the official place to discuss Elm matters on the platform.

A few additional links pertaining to dev.to

Traffic stats: https://www.similarweb.com/website/dev.to
Twitter: https://twitter.com/thepracticaldev
Elm tag (as included in PR): https://dev.to/t/elm

Some example Elm posts:
https://dev.to/rtfeldman/tour-of-an-open-source-elm-spa
https://dev.to/aspittel/how-i-finally-built-an-app-in-elm-a80
https://dev.to/miguelcoba/elixir-api-and-elm-spa-4hpf

Happy coding :heart: