### PR TITLE
0.19 build fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 elm-stuff
+node_modules
+package-lock.json
+bin/
 _site

--- a/src/pages/0.19.0/repl.elm
+++ b/src/pages/0.19.0/repl.elm
@@ -38,8 +38,8 @@ The same can be done with definitions and union types:
 
 > type User = Regular String | Visitor String
 
-> case Regular "Tom" of \
-|   Regular name -> "Hey again!" \
+> case Regular "Tom" of \\
+|   Regular name -> "Hey again!" \\
 |   Visitor name -> "Nice to meet you!"
 "Hey again!" : String
 ```


### PR DESCRIPTION
Looks like character escaping rules may have changed at the last minute for the 0.19 release, breaking the build of this branch. The fix seemed trivial, so I thought I'd send it over. :)

Also updated .gitignore to ignore a bunch of dependencies installed by the build script.