### PR TITLE
Change arg names of `append` to remove shadowing

### DIFF
--- a/src/pages/docs/syntax.elm
+++ b/src/pages/docs/syntax.elm
@@ -274,7 +274,7 @@ their own top-level definitions.
 
 ```elm
 -- alias for appending lists and two lists
-append xs ys = xs ++ ys
+append listOne listTwo = listOne ++ listTwo
 xs = [1,2,3]
 ys = [4,5,6]
 


### PR DESCRIPTION
Since in Elm 0.19 shadowing is now allowed, the example in the "Applying functions" section wasn't compiling, because `xs` and `ys` were shadowed in the `append` function. It's not that big of a deal, but quite a lot of people like to try the examples they encounter, so it's a good idea to keep them up to date. 
I'm also not sure about the comment above `append` – I am a bit confused about what it means. Maybe someone can explain it?