### PR TITLE
Adjust optimize page for latest uglify

### DIFF
--- a/src/pages/0.19.0/optimize.elm
+++ b/src/pages/0.19.0/optimize.elm
@@ -49,7 +49,7 @@ min="elm.min.js"
 
 elm make --optimize --output=$js $@
 
-uglifyjs $js --compress pure_funcs=['F2','F3','F4','F5','F6','F7','F8','F9','A2','A3','A4','A5','A6','A7','A8','A9'],pure_getters,keep_fargs=false,unsafe_comps,unsafe,pure_getters,keep_fargs=false,unsafe_comps,unsafe' | uglifyjs --mangle --output=$min
+uglifyjs $js --compress pure_funcs=['F2','F3','F4','F5','F6','F7','F8','F9','A2','A3','A4','A5','A6','A7','A8','A9'],pure_getters,keep_fargs=false,unsafe_comps,unsafe,pure_getters,keep_fargs=false,unsafe_comps,unsafe | uglifyjs --mangle --output=$min
 
 echo "Initial size: $(cat $js | wc -c) bytes  ($js)"
 echo "Minified size:$(cat $min | wc -c) bytes  ($min)"

--- a/src/pages/0.19.0/optimize.elm
+++ b/src/pages/0.19.0/optimize.elm
@@ -24,7 +24,7 @@ Putting those together, here is how I would optimize `src/Main.elm` with two ter
 
 ```bash
 elm make src/Main.elm --optimize --output=elm.js
-uglifyjs elm.js --compress 'pure_funcs="F2,F3,F4,F5,F6,F7,F8,F9,A2,A3,A4,A5,A6,A7,A8,A9",pure_getters,keep_fargs=false,unsafe_comps,unsafe' | uglifyjs --mangle --output=elm.min.js
+uglifyjs elm.js --compress pure_funcs=['F2','F3','F4','F5','F6','F7','F8','F9','A2','A3','A4','A5','A6','A7','A8','A9'],pure_getters,keep_fargs=false,unsafe_comps,unsafe | uglifyjs --mangle --output=elm.min.js
 ```
 
 After this you will have an `elm.js` and a significantly smaller `elm.min.js` file!
@@ -49,7 +49,7 @@ min="elm.min.js"
 
 elm make --optimize --output=$js $@
 
-uglifyjs $js --compress 'pure_funcs="F2,F3,F4,F5,F6,F7,F8,F9,A2,A3,A4,A5,A6,A7,A8,A9",pure_getters,keep_fargs=false,unsafe_comps,unsafe' | uglifyjs --mangle --output=$min
+uglifyjs $js --compress pure_funcs=['F2','F3','F4','F5','F6','F7','F8','F9','A2','A3','A4','A5','A6','A7','A8','A9'],pure_getters,keep_fargs=false,unsafe_comps,unsafe,pure_getters,keep_fargs=false,unsafe_comps,unsafe' | uglifyjs --mangle --output=$min
 
 echo "Initial size: $(cat $js | wc -c) bytes  ($js)"
 echo "Minified size:$(cat $min | wc -c) bytes  ($min)"


### PR DESCRIPTION
Uglify invocation from:
https://elm-lang.org/0.19.0/optimize

Have outdated parameters style pass. 
New version requires array-like style of passing argument:
https://www.npmjs.com/package/uglify-js#compress-options