### PR TITLE
fixed broken links on bad-recursion and import-cycles pages

### DIFF
--- a/src/pages/0.19.0/bad-recursion.elm
+++ b/src/pages/0.19.0/bad-recursion.elm
@@ -59,7 +59,7 @@ type alias Comment =
 type Responses = Responses (List Comment)
 ```
 
-You may have run into this definition in the [hints for recursive aliases](recursive-alias.md)! Anyway, once you have comments, you may want to turn them into JSON to send back to your server or to store in your database or whatever. So you will probably write some code like this:
+You may have run into this definition in the [hints for recursive aliases](recursive-alias)! Anyway, once you have comments, you may want to turn them into JSON to send back to your server or to store in your database or whatever. So you will probably write some code like this:
 
 ```elm
 import Json.Decode as Decode exposing (Decoder)

--- a/src/pages/0.19.0/import-cycles.elm
+++ b/src/pages/0.19.0/import-cycles.elm
@@ -60,7 +60,7 @@ type alias User =
   }
 ```
 
-Notice that the `Comment` type alias is defined in terms of the `User` type alias and vice versa. Having recursive type aliases like this does not work! That problem is described in depth [here](recursive-alias.md), but the quick takeaway is that one `type alias` needs to become a `type` to break the recursion. So let’s try again:
+Notice that the `Comment` type alias is defined in terms of the `User` type alias and vice versa. Having recursive type aliases like this does not work! That problem is described in depth [here](recursive-alias), but the quick takeaway is that one `type alias` needs to become a `type` to break the recursion. So let’s try again:
 
 ```elm
 module BadCombination2 exposing (..)


### PR DESCRIPTION
fixed broken links on https://elm-lang.org/0.19.0/bad-recursion and https://elm-lang.org/0.19.0/import-cycles pages by removing `.md` extension