### PR TITLE
update url to prevent 404 on first example

### DIFF
--- a/editor/splash.html
+++ b/editor/splash.html
@@ -17,7 +17,7 @@
 		<h1 style="font-weight:normal;">Online Editor</h1>
 		<p>Write and compile code online!</p>
 		<ul>
-			<li><a href="/examples/hello-world" target="_top">Hello World!</a></li>
+			<li><a href="/examples/hello" target="_top">Hello World!</a></li>
 			<li><a href="/examples/buttons" target="_top">Buttons</a></li>
 			<li><a href="/examples/clock" target="_top">Clock</a></li>
 			<li><a href="/examples/cat-gifs" target="_top">Cat GIFs</a></li>


### PR DESCRIPTION
Hey there! 👋 

I clicked on the __"Try"__ button on the homepage, and realized that the first link for "Hello world!" was leading to a 404 page. 😬 

![image](https://user-images.githubusercontent.com/6187256/63794223-24070e00-c8c7-11e9-9aeb-51b6d8bdf1e6.png)

![image](https://user-images.githubusercontent.com/6187256/63794232-28332b80-c8c7-11e9-8567-7fb99fb988c0.png)

By updating the URL from `/examples/hello-world` to `/examples/hello`, we end up in the right place:

![image](https://user-images.githubusercontent.com/6187256/63794264-37b27480-c8c7-11e9-8f0e-724d7007b61f.png)

Hopefully this fix will help beginners get started with the language!