### PR TITLE
Fix/822 Update text fields guide link to the correct URL

### DIFF
--- a/examples/text-fields.elm
+++ b/examples/text-fields.elm
@@ -1,7 +1,7 @@
 -- A text input for reversing text. Very useful!
 --
 -- Read how it works:
---   https://guide.elm-lang.org/architecture/text-fields.html
+--   https://guide.elm-lang.org/architecture/text_fields.html
 --
 
 import Browser


### PR DESCRIPTION
(Fixes #822) I updated the link to the guide's explanation of text fields. The link now loads the appropriate page.