### PR TITLE
Remove `module` declaration from buttons example

### DIFF
--- a/examples/buttons.elm
+++ b/examples/buttons.elm
@@ -1,5 +1,3 @@
-module Main exposing (..)
-
 -- Press buttons to increment and decrement a counter.
 --
 -- Read how it works:


### PR DESCRIPTION
All other examples omit the module declaration. The buttons example is the only one with such a line.

I suggested Elm to some friends, and one asked me what this line was doing since he had not yet been introduced to modules and thus this was new syntax for him. Therefore omitting this unnecessary line simplifies the example and is in line with the reason behind the module declaration being optional:
> Note: If you forget to add a module declaration, Elm will use this one instead:
> ```
>  module Main exposing (..)
> ```
> This makes things easier for beginners working in just one file. They should not be confronted with the module system on their first day!
>
> -- https://guide.elm-lang.org/webapps/modules.html