### PR TITLE
Re-enable CORS access to public-opinion.txt

### DIFF
--- a/static/_headers
+++ b/static/_headers
@@ -1,6 +1,6 @@
-/assets/public-opinion.txt
-  Access-Control-Allow-Origin: *
 /assets/*
   Access-Control-Allow-Origin: https://worker.elm-lang.org
+/assets/public-opinion.txt
+  Access-Control-Allow-Origin: *
 /images/*
   Access-Control-Allow-Origin: https://worker.elm-lang.org


### PR DESCRIPTION
Changing the order of the Access-Control-Allow-Origin rules in _headers (Netlify configuration file) allows /assets/public-opinion.txt to be accessible cross-origin, as it was originally. Intended to resolve #829 .

Testing in a separate Netlify deployment confirms that this change in order should have the desired effect of giving the permissive header for /assets/public-opinion.txt while remaining restrictive for the rest of /assets and /images .