### PR TITLE
Follow moved doc links regarding Elm upgrades

### DIFF
--- a/pages/news/compilers-as-assistants.elm
+++ b/pages/news/compilers-as-assistants.elm
@@ -95,7 +95,7 @@ improving!
 and read the [upgrade docs][upgrade] for a concise list of changes and a
 thorough guide on upgrading your code. Should be quite simple and minimal!
 
-[upgrade]: https://github.com/elm-lang/elm-platform/blob/master/upgrade-docs/0.16.md
+[upgrade]: https://github.com/elm/compiler/blob/master/docs/upgrade-instructions/0.16.md
 
 
 # Improved Error Messages
@@ -299,7 +299,7 @@ more focused. All the changes are listed [here][upgrade-docs], so we will focus
 on the two major changes here: removing multi-way `if` and removing
 field addition/deletion.
 
-[upgrade-docs]: https://github.com/elm-lang/elm-platform/blob/master/upgrade-docs/0.16.md#updating-syntax
+[upgrade-docs]: https://github.com/elm/compiler/blob/master/docs/upgrade-instructions/0.16.md#updating-syntax
 
 
 ### Simplified Ifs

--- a/pages/news/farewell-to-frp.elm
+++ b/pages/news/farewell-to-frp.elm
@@ -84,7 +84,7 @@ too!
 >  - Helpful messages when decoding JSON fails
 
 
-[plan]: https://github.com/elm-lang/elm-platform/blob/master/upgrade-docs/0.17.md
+[plan]: https://github.com/elm/compiler/blob/master/docs/upgrade-instructions/0.17.md
 [arch]: http://guide.elm-lang.org/architecture/index.html
 [guide]: http://guide.elm-lang.org/
 
@@ -196,7 +196,7 @@ And remember, you can always come talk to us on [the Elm Slack channel][slack]!
 We are a friendly bunch that is happy to help folks learning new stuff or
 upgrading old code. Just ask!
 
-[plan]: https://github.com/elm-lang/elm-platform/blob/master/upgrade-docs/0.17.md
+[plan]: https://github.com/elm/compiler/blob/master/docs/upgrade-instructions/0.17.md
 [guide]: http://guide.elm-lang.org/
 [arch]: http://guide.elm-lang.org/architecture/index.html
 [ports]: http://guide.elm-lang.org/interop/javascript.html

--- a/pages/news/small-assets-without-the-headache.elm
+++ b/pages/news/small-assets-without-the-headache.elm
@@ -37,7 +37,7 @@ The best part is that it is easy to get these results. No need to write your cod
 
 The rest of this post will explore (1) the new optimizations that make these results possible, (2) how the new compiler became extremely fast for large projects, and (3) some nice improvements and simplifications.
 
-> **Note:** Check out the full [release notes](https://github.com/elm/compiler/blob/master/upgrade-docs/0.19.md) to see everything that is new in Elm 0.19. The installers are available in the freshly updated [official guide](https://guide.elm-lang.org)!
+> **Note:** Check out the full [release notes](https://github.com/elm/compiler/blob/master/docs/upgrade-instructions/0.19.0.md) to see everything that is new in Elm 0.19. The installers are available in the freshly updated [official guide](https://guide.elm-lang.org)!
 
 
 ## Dead Code Elimination
@@ -98,7 +98,7 @@ I feel like a robot talking about all those numbers. That stuff is nice and all,
 - A simpler way to think about time and time zones in [`elm/time`](https://package.elm-lang.org/packages/elm/time/latest/).
 - The [`getViewport`](https://package.elm-lang.org/packages/elm/browser/latest/Browser-Dom#getViewport) family of functions for getting scroll positions.
 
-These examples showcase the effort that has gone into continually making Elm simpler and friendlier, but there are a bunch of other improvements listed in [the release notes](https://github.com/elm/compiler/blob/master/upgrade-docs/0.19.md) in the same spirit!
+These examples showcase the effort that has gone into continually making Elm simpler and friendlier, but there are a bunch of other improvements listed in [the release notes](https://github.com/elm/compiler/blob/master/docs/upgrade-instructions/0.19.0.md) in the same spirit!
 
 
 ## Conclusion

--- a/pages/news/the-perfect-bug-report.elm
+++ b/pages/news/the-perfect-bug-report.elm
@@ -75,7 +75,7 @@ This blog post also marks the release of Elm 0.18, so from here we are going to 
 > **Note:** Install 0.18 from [here][install], and be sure to read the [migration guide][upgrade]! The latest `elm-format` will do a lot of the migration automatically, so check it out as well.
 
 [install]: https://guide.elm-lang.org/install.html
-[upgrade]: https://github.com/elm-lang/elm-platform/blob/master/upgrade-docs/0.18.md
+[upgrade]: https://github.com/elm/compiler/blob/master/docs/upgrade-instructions/0.18.md
 
 
 # Designing for Real Life
@@ -131,7 +131,7 @@ I am pretty certain the debugger will help beginners understand The Elm Architec
 
 In addition to the debugger, there are some improvements to the error messages and core libraries. I will just be highlighting the most important stuff in this post, so check out the [migration guide][upgrade] for more details!
 
-[upgrade]: https://github.com/elm-lang/elm-platform/blob/master/upgrade-docs/0.18.md
+[upgrade]: https://github.com/elm/compiler/blob/master/docs/upgrade-instructions/0.18.md
 
 
 ## Improved Error Messages
@@ -168,7 +168,7 @@ Elm is already quite a small language, but there are a few oddities that seem to
 Again, all these cases are covered in more detail in [the migration guide][upgrade], and `elm-format` will handle most of these cases automatically. Folks using the 0.18 alpha reported that the upgrade was quite smooth, so feel free to ask for help on [the Elm slack][slack]. The Elm community is friendly and happy to help!
 
 [range]: http://package.elm-lang.org/packages/elm-lang/core/5.0.0/List#range
-[alt]: https://github.com/elm-lang/elm-platform/blob/master/upgrade-docs/0.18.md#backticks-and-andthen
+[alt]: https://github.com/elm/compiler/blob/master/docs/upgrade-instructions/0.18.md#backticks-and-andthen
 [slack]: http://elmlang.herokuapp.com/
 
 


### PR DESCRIPTION
Correct links to upgrade instructions.

It's my fault that I didn't look at the open pull requests. I would have found this identical one: #842.

The links were broken on October 13 (2019) when commits in `elm/compiler` [moved a directory](/elm/compiler/commit/b21f5ded9105b5ffb5af5d7d0b3da03a39e1ff43) and [renamed 0.19 to 0.19.0](https://github.com/elm/compiler/commit/e560ef2c98cb5ddb14480469112d78a986863a1d).

Rather than mere tidiness, I was using these upgrade pages to learn Elm in my own way—but they weren't easy to find!