### PR TITLE
format time example with two digits

### DIFF
--- a/examples/time.elm
+++ b/examples/time.elm
@@ -83,8 +83,11 @@ subscriptions model =
 view : Model -> Html Msg
 view model =
   let
-    hour   = String.fromInt (Time.toHour   model.zone model.time)
-    minute = String.fromInt (Time.toMinute model.zone model.time)
-    second = String.fromInt (Time.toSecond model.zone model.time)
+    twoDigitNumber =
+      String.padLeft 2 '0'
+
+    hour   = String.fromInt (Time.toHour   model.zone model.time) |> twoDigitNumber
+    minute = String.fromInt (Time.toMinute model.zone model.time) |> twoDigitNumber
+    second = String.fromInt (Time.toSecond model.zone model.time) |> twoDigitNumber
   in
   h1 [] [ text (hour ++ ":" ++ minute ++ ":" ++ second) ]


### PR DESCRIPTION
I noticed that the example only displays single-digit numbers (e.g. 12:3:7) which is not a common time format imho. I fixed the example code to display the time as 12:03:07.