### PR TITLE
Set default background color

### DIFF
--- a/static/assets/style.css
+++ b/static/assets/style.css
@@ -3,6 +3,7 @@ html, head, body, pre {
 }
 
 body {
+  background: #fff;
   font-family: 'IBM Plex Sans', sans-serif;
   color: #000E16;
   line-height: 1.5;


### PR DESCRIPTION
I have black-on-black text issues with Firefox on Linux with a dark GTK theme. If a default color is set, a default background should also be set.

Before:

![Screen Shot 2021-11-25 at 17 36 54](https://user-images.githubusercontent.com/561087/143426233-d51a8544-b5d1-4bfb-984b-0962caa0be86.png)

After:

![Screen Shot 2021-11-25 at 17 37 19](https://user-images.githubusercontent.com/561087/143426282-123485d6-7e0e-4689-850e-4385b74ff8cf.png)
