### PR TITLE
Fix search in code editor

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -226,7 +226,6 @@ if ! [ -f _site/assets/editor-codemirror.js ] || ! [ -f _site/assets/editor-elm.
       editor/cm/addon/search/search.js \
       editor/cm/addon/dialog/dialog.js \
       editor/cm/lib/active-line.js \
-      editor/cm/addon/dialog/dialog.js \
       editor/cm/keymap/sublime.js \
       | uglifyjs -o _site/assets/editor-codemirror.js
 
@@ -234,7 +233,7 @@ if ! [ -f _site/assets/editor-codemirror.js ] || ! [ -f _site/assets/editor-elm.
   cat editor/code-editor.js editor/column-divider.js | uglifyjs -o _site/assets/editor-custom-elements.js
 
   # styles
-  cat editor/cm/lib/codemirror.css editor/editor.css > _site/assets/editor-styles.css
+  cat editor/cm/lib/codemirror.css editor/cm/addon/dialog/dialog.css editor/editor.css > _site/assets/editor-styles.css
 
   # elm
   (cd editor ; elm make src/Page/Editor.elm --optimize --output=elm.js)

--- a/editor/cm/addon/dialog/dialog.css
+++ b/editor/cm/addon/dialog/dialog.css
@@ -1,0 +1,32 @@
+.CodeMirror-dialog {
+  position: absolute;
+  left: 0; right: 0;
+  background: inherit;
+  z-index: 15;
+  padding: .1em .8em;
+  overflow: hidden;
+  color: inherit;
+}
+
+.CodeMirror-dialog-top {
+  border-bottom: 1px solid #eee;
+  top: 0;
+}
+
+.CodeMirror-dialog-bottom {
+  border-top: 1px solid #eee;
+  bottom: 0;
+}
+
+.CodeMirror-dialog input {
+  border: none;
+  outline: none;
+  background: transparent;
+  width: 20em;
+  color: inherit;
+  font-family: monospace;
+}
+
+.CodeMirror-dialog button {
+  font-size: 70%;
+}

--- a/editor/code-editor.js
+++ b/editor/code-editor.js
@@ -110,6 +110,9 @@
           value: this._source,
           tabSize: 2,
           indentWithTabs: false,
+          // Increase off-screen lines CodeMirror puts in DOM, for browser's native search.
+          // Won't scale to huge files, hopefully fine for Elm examples.
+          viewportMargin: 500,
           extraKeys: {
             "Tab": handleTab,
             "Shift-Tab": handleUntab,

--- a/editor/code-editor.js
+++ b/editor/code-editor.js
@@ -113,6 +113,9 @@
           extraKeys: {
             "Tab": handleTab,
             "Shift-Tab": handleUntab,
+            // "findPersistent" behavior is closer to browser's native search than "find".
+            "Cmd-F": "findPersistent",
+            "Ctrl-F": "findPersistent",
             "Cmd-S": function(cm) { sendSaveEvent(); },
             "Ctrl-Enter": function(cm) { sendSaveEvent(); }
           }


### PR DESCRIPTION
Search within code was broken on https://elm-lang.org/try and all examples :crying_cat_face: 

1. CodeMirror's builtin search bar was invisible => copied missing `dialog.css` from 
  https://github.com/codemirror/codemirror5/blob/5.40.2/addon/dialog/dialog.css

    | before | after |
    |--------|-------|
    | ![bildo](https://github.com/elm/elm-lang.org/assets/273688/cbf3a056-5897-4901-b7a9-b52d280fb100) | ![bildo](https://github.com/elm/elm-lang.org/assets/273688/1ec10465-9354-406c-983c-6c5c0074d6d0) |

2. Switched CodeMirror's search to "findPersistent" which behaves closer to browser's search.

3. Sometimes user will encounter browser's search anyway (if focus was outside editor, via menu, in Chrome on 2nd Ctrl-F press...).  
   Tuned CodeMirror to keep up to 500 off-screen lines in DOM (default was 10), allowing browser's search to Just Work accurately on all elm examples.  
  (not setting Infinity to avoid slow editor in case user pastes very long code. CM's builtin search is always accurate.)
